### PR TITLE
Environment updates to work with newer version of Moodle

### DIFF
--- a/src/cdk/lib/ecs-moodle-stack.ts
+++ b/src/cdk/lib/ecs-moodle-stack.ts
@@ -69,13 +69,13 @@ export class EcsMoodleStack extends cdk.Stack {
     const cluster = new ecs.Cluster(this, 'ecs-cluster', {
       vpc: vpc,
       clusterName: 'moodle-ecs-cluster',
-      containerInsights: true,
+      containerInsightsV2: ecs.ContainerInsights.ENABLED,
       enableFargateCapacityProviders: true
     });
 
     // RDS
     const moodleDb = new rds.DatabaseInstance(this, 'moodle-db', {
-      engine: rds.DatabaseInstanceEngine.mysql({ version: rds.MysqlEngineVersion.VER_8_0_32}),
+      engine: rds.DatabaseInstanceEngine.mysql({ version: rds.MysqlEngineVersion.VER_8_4_4}),
       vpc: vpc,
       vpcSubnets: { 
         subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS
@@ -225,7 +225,8 @@ export class EcsMoodleStack extends cdk.Stack {
       healthCheckGracePeriod: cdk.Duration.seconds(props.serviceHealthCheckGracePeriodSeconds),
       circuitBreaker: { rollback: true }
     });
-
+    moodleService.node.addDependency(cluster);
+    
     // Moodle ECS Service Task Auto Scaling
     const moodleServiceScaling = moodleService.autoScaleTaskCount({ minCapacity: props.serviceReplicaDesiredCount, maxCapacity: 10 } );
     moodleServiceScaling.scaleOnCpuUtilization('cpu-scaling', {

--- a/src/image/src/Dockerfile
+++ b/src/image/src/Dockerfile
@@ -1,11 +1,11 @@
-FROM bitnami/moodle:4.0.5
+FROM bitnami/moodle:4.5
 RUN apt-get update -y
 
-# Install PHP Redis
-RUN apt-get install -y autoconf wget build-essential && \
-    wget https://pecl.php.net/get/redis-5.3.7.tgz && \
-    tar xzf redis-5.3.7.tgz && \
-    cd redis-5.3.7 && \
+# Install PHP Redis and gosu
+RUN apt-get install -y autoconf wget build-essential gosu
+RUN wget https://pecl.php.net/get/redis-6.2.0.tgz && \
+    tar xzf redis-6.2.0.tgz && \
+    cd redis-6.2.0 && \
     phpize && \
     ./configure && \
     make && \
@@ -13,8 +13,8 @@ RUN apt-get install -y autoconf wget build-essential && \
     echo "extension=redis.so" >> /opt/bitnami/php/etc/php.ini && \
     apt-get purge --autoremove -y autoconf wget build-essential && \
     cd .. && \
-    rm redis-5.3.7.tgz && \
-    rm -rf redis-5.3.7
+    rm redis-6.2.0.tgz && \
+    rm -rf redis-6.2.0
 
 # Copy the updated libmoodle.sh
 COPY ./libmoodle.sh /opt/bitnami/scripts/libmoodle.sh


### PR DESCRIPTION
Tested with the following base images:
- bitnami/moodle:4.5
- bitnami/moodle:5.0

*Issue #30*

*Description of changes:*

- Updated base image to bitnami/moodle:4.5
- Updated PHP Redis and MySQL versions so works correctly with newer versions of Moodle.  
- Updated depreciated CDK parameter for Container Insights.  
- Added dependency between ECS Service and Cluster to enable clean deletion of stack.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
