### PR TITLE
fix: resolve ReDoS vulnerability in domain validation regex

### DIFF
--- a/src/cdk/bin/cdk.ts
+++ b/src/cdk/bin/cdk.ts
@@ -133,7 +133,7 @@ function validateCertificateConfiguration(
       throw new Error('domain must be set when certificate ARN is not provided');
     }
     // Validate domain format (must have at least one dot)
-    const domainPattern = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]?(\.[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]?)+$/;
+    const domainPattern = /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)(?:\.(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?))+$/;
     if (!domainPattern.test(domain)) {
       throw new Error(`Invalid domain format: ${domain}`);
     }


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Restructure domainPattern to eliminate catastrophic backtracking caused by ambiguous overlap between [a-zA-Z0-9-]{0,61} and the optional trailing [a-zA-Z0-9]?. The new pattern uses non-capturing groups to make label matching deterministic while accepting the same valid inputs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
